### PR TITLE
Polished things in real-world scenario

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,9 +32,11 @@ Example configuration. 👇
 ```js
 {
     rules: {
-        "@productboardlabs/smart-color-replacement": {
-            "@snowWhite": "#f4f5e2"
-        }
+        "@productboard/smart-color-replacement": [
+            {
+                "@snowWhite": "#f4f5e2"
+            }
+        ]
     }
 }
 ```
@@ -43,11 +45,16 @@ You can also run this rule in **strict mode** which means that there is no other
 
 ```js
 {
-    rules: {
-        "@productboardlabs/smart-color-replacement": [{
-            "@snowWhite": "#f4f5e2"
-        }, "strictMode"]
-    }
+  "rules": {
+    "@productboard/smart-color-replacement": [
+      {
+        "@white": "#ffffff"
+      },
+      {
+        "strictMode": true
+      }
+    ]
+  }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@productboard/stylelint-pb",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "src/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest"

--- a/src/rules/__tests__/smart-color-replacement.test.js
+++ b/src/rules/__tests__/smart-color-replacement.test.js
@@ -37,6 +37,10 @@ testRule(rule, {
     {
       code: "a { color: #333333; }",
       description: "Color out of the config should be ignored by default"
+    },
+    {
+      code: "a { box-shadow: 0 1px 2px rgb(broken, 0.3); }",
+      description: "non-parsable colors should be ignored"
     }
   ],
 
@@ -86,9 +90,16 @@ testRule(rule, {
     {
       "@snowWhite": "#f4f5e2"
     },
-    "strictMode"
+    { strictMode: true }
   ],
   fix: true,
+
+  accept: [
+    {
+      code: "a { box-shadow: 0 1px 2px rgb(broken, 0.3); }",
+      description: "non-parsable colors should be ignored"
+    }
+  ],
 
   reject: [
     {


### PR DESCRIPTION
- Fixed case where we can't parse the color
- Ignored `rgba` because color can't work with alpha (in hex)